### PR TITLE
Improve arbiter documentation

### DIFF
--- a/actix/src/sec-5-arbiter.md
+++ b/actix/src/sec-5-arbiter.md
@@ -16,24 +16,17 @@ running inside of the System Arbiter's thread. In many cases, this is all you
 will need for a program using Actix.
 
 While it only uses one thread, it uses the very efficient event loop pattern
-which works well for asynchronous events. To handle synchronous tasks that
-require heavy CPU power, it's better to avoid blocking the event loop and
-instead offload the computation to other threads. For this usecase, read the
-next section and consider using [`SyncArbiter`](./sec-6-sync-arbiter.md).
+which works well for asynchronous events. To handle synchronous, CPU-bound
+tasks, it's better to avoid blocking the event loop and instead offload the
+computation to other threads. For this usecase, read the next section and
+consider using [`SyncArbiter`](./sec-6-sync-arbiter.md).
 
 ## The event loop
 
-> If you're familiar with event loops in other paradigms, such as libuv (upon
-> which Node runs) or tokio (upon which Actix is implemented), each Arbiter has
-> a similar processing paradigm.
-
-> Specifically, if you're familiar with how JavaScript handles asynchronicity
-> and how the single-threaded model makes it so JS mostly doesn't need
-> synchronization primitives, this should feel very familiar to you.
-
 One `Arbiter` is in control of one thread with one task queue, and when tasks
 get spawned in an Actor's context or using `Arbiter::spawn`, the task gets
-queued up for execution in that thread.
+queued up for execution in that thread. When you think `Arbiter`, you can think
+"single-threaded event loop".
 
 If you pay close attention to way both `ActorFuture` and the methods in the
 `Actor` trait specify their parameters, actor behavior always references both
@@ -43,20 +36,12 @@ rights to the actor and its context. This is achieved by putting all actor logic
 in the same thread, so we know no two pieces of logic involving the actor are
 running concurrently without having to use synchronization primitives.
 
-While the library is written with an asynchronous, event-driven flow, and while
-the library otherwise enables concurrency, each Actor specifically runs on one
-thread. Each task gets coordinated by the Arbiter to run eventually, but always
-on the same thread. So when a Future is spawned on the Arbiter (using
-`Arbiter::spawn` or the more common `Context::spawn`), it will execute within
-the same execution context (thread), allowing the Future full access to the
-state while avoiding synchronization (such as `Mutex`es).
-
-When you create a new Arbiter, this creates a new execution context for Actors.
-The new thread is available to add new Actors to it, but Actors cannot freely
-move between Arbiters: they are tied to the Arbiter they were spawned in.
-However, Actors on different Arbiters can still communicate with each other
-using the normal `Addr`/`Recipient` methods. The method of passing messages is
-agnostic to whether the Actors are running on the same or different Arbiters.
+Actix in general does support concurrency, but normal `Arbiter`s (not
+`SyncArbiter`s) do not. To use Actix in a concurrent way, you can spin up
+multiple `Arbiter`s using `Arbiter::new`, `ArbiterBuilder`, or `Arbiter::start`.
+Each `Arbiter` will represent one thread Actors can communicate using `Addr`s
+and `Recipient`s with other Actors regardless of which Arbiter the Actors are
+on.
 
 ## Using Arbiter for resolving async events
 
@@ -134,10 +119,6 @@ fn main() {
         // Assuming the send was successful, chain another computation
         //   onto the future. Returning a future from `and_then` chains
         //   that computation to the end of the existing future.
-        //
-        // In this case, because the `Arbiter` is executing the futures,
-        //   the result of `dis_addr.send` (also a `Response`) will be
-        //   spawned and executed on the Arbiter in the same thread.
         .and_then(move |res| {
             // `res` is now the `usize` returned from
 

--- a/actix/src/sec-5-arbiter.md
+++ b/actix/src/sec-5-arbiter.md
@@ -23,10 +23,10 @@ consider using [`SyncArbiter`](./sec-6-sync-arbiter.md).
 
 ## The event loop
 
-One `Arbiter` is in control of one thread with one task queue, and when tasks
-get spawned in an Actor's context or using `Arbiter::spawn`, the task gets
-queued up for execution in that thread. When you think `Arbiter`, you can think
-"single-threaded event loop".
+One `Arbiter` is in control of one thread with one event pool. When an Arbiter
+spawns a task (via `Arbiter::spawn`, `Context<Actor>::run_later`, or similar
+constructs), the Arbiter queues the task for execution on that task queue. When
+you think `Arbiter`, you can think "single-threaded event loop".
 
 If you pay close attention to way both `ActorFuture` and the methods in the
 `Actor` trait specify their parameters, actor behavior always references both

--- a/actix/src/sec-5-arbiter.md
+++ b/actix/src/sec-5-arbiter.md
@@ -28,20 +28,16 @@ spawns a task (via `Arbiter::spawn`, `Context<Actor>::run_later`, or similar
 constructs), the Arbiter queues the task for execution on that task queue. When
 you think `Arbiter`, you can think "single-threaded event loop".
 
-If you pay close attention to way both `ActorFuture` and the methods in the
-`Actor` trait specify their parameters, actor behavior always references both
-the actor and the context as mutable: `&mut self` (or `&mut A` in `ActorFuture`)
-and `&mut Self::Context`. This is because all of these tasks have **exclusive**
-rights to the actor and its context. This is achieved by putting all actor logic
-in the same thread, so we know no two pieces of logic involving the actor are
-running concurrently without having to use synchronization primitives.
-
 Actix in general does support concurrency, but normal `Arbiter`s (not
 `SyncArbiter`s) do not. To use Actix in a concurrent way, you can spin up
 multiple `Arbiter`s using `Arbiter::new`, `ArbiterBuilder`, or `Arbiter::start`.
-Each `Arbiter` will represent one thread Actors can communicate using `Addr`s
-and `Recipient`s with other Actors regardless of which Arbiter the Actors are
-on.
+
+When you create a new Arbiter, this creates a new execution context for Actors.
+The new thread is available to add new Actors to it, but Actors cannot freely
+move between Arbiters: they are tied to the Arbiter they were spawned in.
+However, Actors on different Arbiters can still communicate with each other
+using the normal `Addr`/`Recipient` methods. The method of passing messages is
+agnostic to whether the Actors are running on the same or different Arbiters.
 
 ## Using Arbiter for resolving async events
 

--- a/actix/src/sec-5-arbiter.md
+++ b/actix/src/sec-5-arbiter.md
@@ -1,12 +1,12 @@
 # Arbiter
 
-Arbiters provide an asynchronous execution context for actors. Where an Actor
-contains a Context that defines it's Actor specific execution state, Arbiters
-host the environment where an actor runs.
+`Arbiter`s provide an asynchronous execution context for `Actor`s. Where an
+actor contains a `Context` that defines its Actor specific execution state,
+Arbiters host the environment where an actor runs.
 
-As a result Arbiters perform a number of function. Most notably, they are able
-to spawn a new OS thread, run an event loop, spawn tasks asynchronously on
-that event loop, and act as helpers for asynchronous tasks.
+As a result Arbiters perform a number of functions. Most notably, they are able
+to spawn a new OS thread, run an event loop, spawn tasks asynchronously on that
+event loop, and act as helpers for asynchronous tasks.
 
 ## System and Arbiter
 
@@ -15,13 +15,55 @@ for your actors to run inside. When you call `start()` on your actor it is then
 running inside of the System Arbiter's thread. In many cases, this is all you
 will need for a program using Actix.
 
+While it only uses one thread, it uses the very efficient event loop pattern
+which works well for asynchronous events. To handle synchronous tasks that
+require heavy CPU power, it's better to avoid blocking the event loop and
+instead offload the computation to other threads. For this usecase, read the
+next section and consider using [`SyncArbiter`](./sec-6-sync-arbiter.md).
+
+## The event loop
+
+> If you're familiar with event loops in other paradigms, such as libuv (upon
+> which Node runs) or tokio (upon which Actix is implemented), each Arbiter has
+> a similar processing paradigm.
+
+> Specifically, if you're familiar with how JavaScript handles asynchronicity
+> and how the single-threaded model makes it so JS mostly doesn't need
+> synchronization primitives, this should feel very familiar to you.
+
+One `Arbiter` is in control of one thread with one task queue, and when tasks
+get spawned in an Actor's context or using `Arbiter::spawn`, the task gets
+queued up for execution in that thread.
+
+If you pay close attention to way both `ActorFuture` and the methods in the
+`Actor` trait specify their parameters, actor behavior always references both
+the actor and the context as mutable: `&mut self` (or `&mut A` in `ActorFuture`)
+and `&mut Self::Context`. This is because all of these tasks have **exclusive**
+rights to the actor and its context. This is achieved by putting all actor logic
+in the same thread, so we know no two pieces of logic involving the actor are
+running concurrently without having to use synchronization primitives.
+
+While the library is written with an asynchronous, event-driven flow, and while
+the library otherwise enables concurrency, each Actor specifically runs on one
+thread. Each task gets coordinated by the Arbiter to run eventually, but always
+on the same thread. So when a Future is spawned on the Arbiter (using
+`Arbiter::spawn` or the more common `Context::spawn`), it will execute within
+the same execution context (thread), allowing the Future full access to the
+state while avoiding synchronization (such as `Mutex`es).
+
+When you create a new Arbiter, this creates a new execution context for Actors.
+The new thread is available to add new Actors to it, but Actors cannot freely
+move between Arbiters: they are tied to the Arbiter they were spawned in.
+However, Actors on different Arbiters can still communicate with each other
+using the normal `Addr`/`Recipient` methods. The method of passing messages is
+agnostic to whether the Actors are running on the same or different Arbiters.
+
 ## Using Arbiter for resolving async events
 
-If you aren't an expert in rust futures, Arbiter can be a helpful
-and simple wrapper to resolving async events in order. Consider
-we have two actors, A and B, and we want to run an event on B
-only once a result from A is completed. We can use Arbiter::spawn
-to assist with this task.
+If you aren't an expert in Rust Futures, Arbiter can be a helpful and simple
+wrapper to resolving async events in order. Consider we have two actors, A and
+B, and we want to run an event on B only once a result from A is completed. We
+can use `Arbiter::spawn` to assist with this task.
 
 ```rust
 # extern crate actix;


### PR DESCRIPTION
Right now this is kind of redundant on #24 for the README. Once that's pulled, the PR will look cleaner and only one file will have changed.

Mostly this PR encompasses 2 major changes to the `Arbiter` page:

- Describes the event loop that Actix/arbiters use
  - I speak maybe too specifically to people who are familiar with JS because that's me and this is the way it made clearest sense to me.
  - I could be totally wrong. Part of this PR is a question: Is this the way it works?
- Make example much cleaner and more user friendly with more comments and explanation.
  - I spend perhaps too much time explaining the Futures aspect, but I think a lot of people who are new to Actix are also at least somewhat new to Futures. This is Rust: everyone's new to everything. So I erred on the side of over-explaining.