### PR TITLE
Re-enable tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
-sudo: false
-dist: trusty
+dist: bionic
 
 cache:
   cargo: false
@@ -14,14 +13,11 @@ matrix:
   allow_failures:
     - rust: nightly
 
-# script:
-#  - |
-#       #cargo clean
-#       RUST_BACKTRACE=1 cargo test -- --nocapture
+script:
+  - cargo test --verbose
 
 # Upload docs
-# after_success:
-script:
+after_success:
   - export PATH=$PATH:~/.cargo/bin
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PULL_REQUEST" = "false" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_RUST_VERSION" == "beta" ]]; then


### PR DESCRIPTION
So these tests were disabled about a year back in 2db214f and it actually resulted in the book getting broken unnoticed (see #33). I suggest re-enabling these tests. They were apparently broken due to travis failures.