### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ src="src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-actix = "^0.7"
+actix = "^0.8"
 
 flate2 = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-serde_urlencoded = "0.5"
+serde_urlencoded = "0.6"
 
 # io
 bytes = "0.4"
@@ -33,7 +33,7 @@ futures = "0.1"
 http = "0.1"
 
 [dev-dependencies]
-env_logger = "0.5"
+env_logger = "0.6"
 skeptic = "0.13"
 serde_derive = "1.0"
 


### PR DESCRIPTION
This will fix the build in the other PR. We need at least actix 0.8 for that. I took the liberty and bumped the other deps as well. The tests still work as you will see after me re-enabling the travis tests.