### PR TITLE
:pencil2: Fixed a typo on sec-2 examples

### DIFF
--- a/actix/src/sec-2-actor.md
+++ b/actix/src/sec-2-actor.md
@@ -155,7 +155,7 @@ fn main() {
 #           System::current().stop();
         })
         .map_err(|e| {
-            println!("Actor is probably died: {}", e);
+            println!("Actor is probably dead: {}", e);
         }));
 
     sys.run();
@@ -257,7 +257,7 @@ fn main() {
 #               System::current().stop();
             })
             .map_err(|e| {
-                println!("Actor is probably died: {}", e);
+                println!("Actor is probably dead: {}", e);
             }),
     );
 
@@ -272,7 +272,7 @@ fn main() {
 #               System::current().stop();
             })
             .map_err(|e| {
-                println!("Actor is probably died: {}", e);
+                println!("Actor is probably dead: {}", e);
             }),
     );
 


### PR DESCRIPTION
The sentence still did make sense before, but for people who don't speak English very well, it might be better to write it clean and simple here