### PR TITLE
Fix context link

### DIFF
--- a/actix/src/sec-2-actor.md
+++ b/actix/src/sec-2-actor.md
@@ -7,7 +7,7 @@ allows applications to be written as a group of independently executing but coop
 "Actors" which communicate via messages. Actors are objects which encapsulate
 state and behavior and run within the *Actor System* provided by the actix library.
 
-Actors run within a specific execution context [*Context<A>*](../actix/struct.Context.html).
+Actors run within a specific execution context [*Context<A>*](./sec-4-context.html).
 The context object is available only during execution. Each actor has a separate
 execution context. The execution context also controls the lifecycle of an actor.
 


### PR DESCRIPTION
The docs as currently rendered on https://actix.rs/book/actix/sec-2-actor.html have a broken link to https://actix.rs/book/actix/struct.Context.html -- the correct target appears to be https://actix.rs/book/actix/sec-4-context.html.