### PR TITLE
fixed steps of running actix ping example

### DIFF
--- a/actix/src/sec-0-quick-start.md
+++ b/actix/src/sec-0-quick-start.md
@@ -27,6 +27,7 @@ commands runs the `ping` example:
 
 ```bash
 git clone https://github.com/actix/actix
+cd actix
 cargo run --example ping
 ```
 


### PR DESCRIPTION
example commands will cases that failure:

```bash
error: could not find `Cargo.toml` in `/` or any parent directory
```