### PR TITLE
Fix links to examples

### DIFF
--- a/actix/src/sec-0-quick-start.md
+++ b/actix/src/sec-0-quick-start.md
@@ -31,4 +31,4 @@ cd actix
 cargo run --example ping
 ```
 
-Check [examples/](https://github.com/actix/actix/tree/master/examples) directory for more examples.
+Check [examples/](https://github.com/actix/actix/tree/master/actix/examples) directory for more examples.

--- a/actix/src/sec-1-getting-started.md
+++ b/actix/src/sec-1-getting-started.md
@@ -156,4 +156,4 @@ async fn main() {
 
 `#[actix_rt::main]` starts the system and block until future resolves.
 
-The Ping example is available in the [examples directory](https://github.com/actix/actix/tree/master/examples/).
+The Ping example is available in the [examples directory](https://github.com/actix/actix/tree/master/actix/examples/).


### PR DESCRIPTION
I noticed that links to the actix examples directory are invalid
(for ex. at the end of https://actix.rs/book/actix/sec-1-getting-started.html). This PR fixes them.