### PR TITLE
Update actix version

### DIFF
--- a/actix/src/sec-1-getting-started.md
+++ b/actix/src/sec-1-getting-started.md
@@ -20,8 +20,8 @@ contains the following:
 
 ```toml
 [dependencies]
-actix = "0.10.0"
-actix-rt = "1.1" # <-- Runtime for actix
+actix = "0.11.0"
+actix-rt = "2.2" # <-- Runtime for actix
 ```
 
 Let's create an actor that will accept a `Ping` message and respond with the number of pings processed.


### PR DESCRIPTION
This update is important because version 1.1 of actix-rt crashes on windows due to [this error](https://github.com/tokio-rs/tokio/issues/999) in tokio.

Version 1.1 of actix-rt was actually yanked from crates.io as well.

For developers on windows following this guide, their programs won't run until this is changed.