### PR TITLE
Update some actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.version }}
         uses: actions-rs/toolchain@v1
@@ -36,15 +36,14 @@ jobs:
         with:
           command: generate-lockfile
       - name: Cache cargo dirs
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path:
-            ~/.cargo/registry
+          path: ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-trimmed-${{ hashFiles('**/Cargo.lock') }}
       - name: Cache cargo build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.40.0 #MSRV
           - stable
           - beta
           - nightly
@@ -25,42 +24,20 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.version }}-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+        run: |
+          rustup install --profile=minimal ${{ matrix.version }}-x86_64-unknown-linux-gnu
+          rustup override set ${{ matrix.version }}-x86_64-unknown-linux-gnu
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
-      - name: Cache cargo dirs
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-trimmed-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ matrix.version }}-x86_64-unknown-linux-gnu-cargo-build-trimmed-${{ hashFiles('**/Cargo.lock') }}
+        run: cargo generate-lockfile
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
       - name: Build book and check links
         if: matrix.version == 'stable'
         run: |
-          cargo install mdbook --no-default-features --version 0.4.5
-          cargo install mdbook-linkcheck --version 0.7.2
+          cargo install mdbook --no-default-features --version 0.4.21
+          cargo install mdbook-linkcheck --version 0.7.7
           mdbook build ./actix/
-
-      - name: Clear the cargo caches
-        run: |
-          cargo install cargo-cache --no-default-features --features ci-autoclean
-          cargo-cache

--- a/.github/workflows/upload-doc.yml
+++ b/.github/workflows/upload-doc.yml
@@ -4,32 +4,44 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    if: github.repository == 'actix/book'
-
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
-
-      - name: Upload documentation
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: Build the book
         run: |
-          cargo install mdbook --no-default-features --version 0.4.5
-          cargo install mdbook-linkcheck --version 0.7.2
-          mdbook build ./actix/ -d ../target/doc/actix
-          cp -r ./target/doc/actix/html/* ./target/doc/actix/
-          rm -r ./target/doc/actix/html ./target/doc/actix/linkcheck
-
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.1
+          rustup override set stable
+          rustup update stable
+          cargo install mdbook --version=0.4.21
+          cargo install mdbook-linkcheck --version=0.7.7
+          mdbook build ./actix/
+          cp -r ./actix/book/html/* ./actix/book
+          rm -r ./actix/book/html ./actix/book/linkcheck
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          branch: gh-pages
-          folder: target/doc
+          path: 'actix/book'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/upload-doc.yml
+++ b/.github/workflows/upload-doc.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'actix/book'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
- Update/remove some actions to remove deprecation warnings
- gh-pages is now deployed via GHA directly
- removed MSRV check as we do that on the actix repo and it should be enough

Signed-off-by: Yuki Okushi <jtitor@2k36.org>